### PR TITLE
Feat/add server context to routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM denoland/deno:2.1.1
+
+EXPOSE 8000
+
+WORKDIR /app
+
+COPY . .
+RUN deno install
+
+RUN deno task db:migrateAll
+# Compile the main app so that it doesn't need to be compiled each startup/entry.
+RUN deno cache main.ts
+
+CMD ["run", "--allow-read", "--allow-env", "--allow-write", "--allow-net", "--allow-ffi", "main.ts"]

--- a/database/db.ts
+++ b/database/db.ts
@@ -6,6 +6,9 @@ type Connection = {
   [Symbol.dispose]: () => void;
 };
 
+/**
+ * Can be used with the `using` keyword for quick and dirty access
+ */
 export function getConnection(): Connection {
   const db = new Database(DB_PATH);
   return {
@@ -14,4 +17,26 @@ export function getConnection(): Connection {
       db.close();
     },
   };
+}
+
+let db: Database;
+
+/**
+ * Get a singleton reference to the db
+ */
+export function getDb(): Database {
+  if (!db) {
+    db = new Database(DB_PATH);
+  }
+
+  return db;
+}
+
+/**
+ * Close the singleton reference to the db
+ */
+export function closeDb(): void {
+  if (db) {
+    db.close();
+  }
 }

--- a/fresh.config.ts
+++ b/fresh.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "$fresh/server.ts";
 import tailwind from "$fresh/plugins/tailwind.ts";
+import { Context } from "./types/request.ts";
+
+await Context.init();
 
 export default defineConfig({
   plugins: [tailwind()],

--- a/main.ts
+++ b/main.ts
@@ -9,15 +9,16 @@ import "$std/dotenv/load.ts";
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 import config from "./fresh.config.ts";
-import { getConnection } from "./database/db.ts";
+import { closeDb } from "./database/db.ts";
 
 function sigIntHandler() {
-  const { db } = getConnection();
   console.log("Received SIGINT, cleaning up");
   Deno.removeSignalListener("SIGINT", sigIntHandler);
+
   console.log("Closing DB...");
-  db.close();
+  closeDb();
   console.log("Closed DB successfully!");
+
   Deno.exit(0);
 }
 

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -3,7 +3,7 @@ import { getCookies } from "$std/http/cookie.ts";
 import { PROTECTED_ROUTES } from "../constants/routes.ts";
 import { getConnection } from "../database/db.ts";
 import { findUserById } from "../database/query/user.ts";
-import { RequestState } from "../types/request.ts";
+import { State } from "../types/request.ts";
 import { decodeSession } from "../utils/session.ts";
 
 export async function authMiddleware({
@@ -11,7 +11,7 @@ export async function authMiddleware({
   ctx,
 }: {
   req: Request;
-  ctx: FreshContext<RequestState>;
+  ctx: FreshContext<State>;
 }) {
   const url = new URL(req.url);
   if (url.pathname.match(/.+\.\w+$/)) {

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -32,7 +32,10 @@ export async function authMiddleware({
   }
 
   if (encodedSession) {
-    const session = await decodeSession(encodedSession, ctx.state.context.sessionKeyAndIv);
+    const session = await decodeSession(
+      encodedSession,
+      ctx.state.context.sessionKeyAndIv,
+    );
 
     using connection = getConnection();
     const user = findUserById(connection.db, session.userId);

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -32,7 +32,7 @@ export async function authMiddleware({
   }
 
   if (encodedSession) {
-    const session = await decodeSession(encodedSession);
+    const session = await decodeSession(encodedSession, ctx.state.context.sessionKeyAndIv);
 
     using connection = getConnection();
     const user = findUserById(connection.db, session.userId);

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,10 +1,26 @@
 import { FreshContext } from "$fresh/server.ts";
 import { authMiddleware } from "../middleware/auth.ts";
-import { RequestState } from "../types/request.ts";
+import { RequestState, Context } from "../types/request.ts";
+
+// memo: https://fresh.deno.dev/docs/examples/init-the-server
+// export async function handler(
+//   _req: Request,
+//   ctx: FreshContext<State>,
+// ) {
+//   ctx.state.context = Context.instance();
+//   if (ctx.destination === "route") {
+//     console.log("i'm logged during a request!");
+//     console.log(ctx.state.context);
+//   }
+//   const resp = await ctx.next();
+//   return resp;
+// }
 
 export async function handler(
   req: Request,
   ctx: FreshContext<RequestState>,
 ) {
+  ctx.state.context = Context.instance();
+
   return await authMiddleware({ req, ctx });
 }

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,6 +1,6 @@
 import { FreshContext } from "$fresh/server.ts";
 import { authMiddleware } from "../middleware/auth.ts";
-import { RequestState, Context } from "../types/request.ts";
+import { State, Context } from "../types/request.ts";
 
 // memo: https://fresh.deno.dev/docs/examples/init-the-server
 // export async function handler(
@@ -18,7 +18,7 @@ import { RequestState, Context } from "../types/request.ts";
 
 export async function handler(
   req: Request,
-  ctx: FreshContext<RequestState>,
+  ctx: FreshContext<State>,
 ) {
   ctx.state.context = Context.instance();
 

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,6 +1,6 @@
 import { FreshContext } from "$fresh/server.ts";
 import { authMiddleware } from "../middleware/auth.ts";
-import { State, Context } from "../types/request.ts";
+import { Context, State } from "../types/request.ts";
 
 // memo: https://fresh.deno.dev/docs/examples/init-the-server
 // export async function handler(

--- a/routes/admin/movie.tsx
+++ b/routes/admin/movie.tsx
@@ -5,6 +5,7 @@ import Button from "../../islands/Button.tsx";
 import { InputField } from "../../islands/form/mod.ts";
 import { z } from "zod";
 import { errorsToString } from "../../utils/forms.ts";
+import { State } from "../../types/request.ts";
 
 const createMovieSchema = z.object({
   name: z.string().min(1),
@@ -13,13 +14,12 @@ const createMovieSchema = z.object({
   icon: z.string(),
 });
 
-export const handler: Handlers = {
+export const handler: Handlers<MoviesProps, State> = {
   async GET(_req, ctx) {
-    using connection = getConnection();
-    return await ctx.render({ movies: findMovies(connection.db) });
+    return await ctx.render({ movies: findMovies(ctx.state.context.db) });
   },
   async POST(req, ctx) {
-    using connection = getConnection();
+    const { db } = ctx.state.context;
 
     const form = await req.formData();
     const name = form.get("name")?.toString() || "";
@@ -39,20 +39,20 @@ export const handler: Handlers = {
           message: errorsToString(parsed.error.errors),
           type: "error",
         },
-        movies: findMovies(connection.db),
+        movies: findMovies(db),
       });
     }
 
     try {
       const { data } = parsed;
-      createMovie(connection.db, data);
+      createMovie(db, data);
 
       return ctx.render({
         flash: {
           message: `Movie successfully created`,
           type: "success",
         },
-        movies: findMovies(connection.db),
+        movies: findMovies(db),
       });
     } catch (e) {
       console.error(e);
@@ -61,7 +61,7 @@ export const handler: Handlers = {
           message: `Error creating movie`,
           type: "error",
         },
-        movies: findMovies(connection.db),
+        movies: findMovies(db),
       });
     }
   },

--- a/routes/login.tsx
+++ b/routes/login.tsx
@@ -7,6 +7,7 @@ import { InputField } from "../islands/form/mod.ts";
 import { z } from "zod";
 import { checkPassword } from "../utils/auth.ts";
 import { encodeSession } from "../utils/session.ts";
+import { RequestState } from "../types/request.ts";
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -14,7 +15,7 @@ const loginSchema = z.object({
 });
 
 export const handler = {
-  async POST(req: Request, ctx: FreshContext) {
+  async POST(req: Request, ctx: FreshContext<RequestState>) {
     using connection = getConnection();
 
     const form = await req.formData();
@@ -42,7 +43,7 @@ export const handler = {
       const headers = new Headers();
       setCookie(headers, {
         name: "auth",
-        value: await encodeSession({ userId: user.id }),
+        value: await encodeSession({ userId: user.id }, ctx.state.context.sessionKeyAndIv),
         sameSite: "Strict",
         httpOnly: true,
         maxAge: 1000 * 60 * 60 * 24,

--- a/routes/login.tsx
+++ b/routes/login.tsx
@@ -7,7 +7,7 @@ import { InputField } from "../islands/form/mod.ts";
 import { z } from "zod";
 import { checkPassword } from "../utils/auth.ts";
 import { encodeSession } from "../utils/session.ts";
-import { RequestState } from "../types/request.ts";
+import { State } from "../types/request.ts";
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -15,7 +15,7 @@ const loginSchema = z.object({
 });
 
 export const handler = {
-  async POST(req: Request, ctx: FreshContext<RequestState>) {
+  async POST(req: Request, ctx: FreshContext<State>) {
     using connection = getConnection();
 
     const form = await req.formData();

--- a/routes/user/event.tsx
+++ b/routes/user/event.tsx
@@ -1,8 +1,8 @@
 import { FreshContext, PageProps } from "$fresh/server.ts";
-import { RequestState } from "../../types/request.ts";
+import { State } from "../../types/request.ts";
 
 export const handler = {
-  GET(_req: Request, ctx: FreshContext<RequestState>) {
+  GET(_req: Request, ctx: FreshContext<State>) {
     return ctx.render();
   },
 };

--- a/routes/user/index.tsx
+++ b/routes/user/index.tsx
@@ -1,8 +1,8 @@
 import { FreshContext } from "$fresh/server.ts";
-import { RequestState } from "../../types/request.ts";
+import { State } from "../../types/request.ts";
 
 export const handler = {
-  GET(_req: Request, _ctx: FreshContext<RequestState>) {
+  GET(_req: Request, _ctx: FreshContext<State>) {
     return new Response(null, {
       headers: { Location: "/user/event" },
       status: 303,

--- a/routes/user/logout.tsx
+++ b/routes/user/logout.tsx
@@ -1,9 +1,9 @@
 import { FreshContext } from "$fresh/server.ts";
 import { deleteCookie } from "$std/http/cookie.ts";
-import { RequestState } from "../../types/request.ts";
+import { State } from "../../types/request.ts";
 
 export const handler = {
-  POST(_req: Request, ctx: FreshContext<RequestState>) {
+  POST(_req: Request, ctx: FreshContext<State>) {
     const { user } = ctx.state;
     const headers = new Headers();
 

--- a/types/request.ts
+++ b/types/request.ts
@@ -25,7 +25,7 @@ export class Context {
   }
 }
 
-export interface RequestState {
+export interface State {
   user: User | null;
   context: Context;
 }

--- a/types/request.ts
+++ b/types/request.ts
@@ -1,15 +1,19 @@
 import { User } from "../database/query/user.ts";
 import { createSessionKeyAndIv, SessionKeyAndIv } from "../utils/session.ts";
 import { SESSION_TOKEN } from "../config.ts";
+import { Database } from "jsr:@db/sqlite@0.11";
+import { getDb } from "../database/db.ts";
 
 let sessionKeyAndIv: SessionKeyAndIv;
 
 export class Context {
   private static context: Context;
   public sessionKeyAndIv: SessionKeyAndIv;
+  public db: Database;
 
   public constructor(sessionKeyAndIv: SessionKeyAndIv) {
     this.sessionKeyAndIv = sessionKeyAndIv;
+    this.db = getDb();
   }
 
   public static async init() {

--- a/types/request.ts
+++ b/types/request.ts
@@ -1,7 +1,33 @@
 import { User } from "../database/query/user.ts";
+import { createSessionKeyAndIv, SessionKeyAndIv } from "../utils/session.ts";
+import { SESSION_TOKEN } from "../config.ts";
+
+let sessionKeyAndIv: SessionKeyAndIv;
+
+export class Context {
+  private static context: Context;
+  public sessionKeyAndIv: SessionKeyAndIv;
+
+  public constructor(sessionKeyAndIv: SessionKeyAndIv) {
+    this.sessionKeyAndIv = sessionKeyAndIv;
+  }
+
+  public static async init() {
+    if (!sessionKeyAndIv) {
+      sessionKeyAndIv = await createSessionKeyAndIv(SESSION_TOKEN);
+    }
+    Context.context = new Context(sessionKeyAndIv);
+  }
+
+  public static instance() {
+    if (this.context) return this.context;
+    else throw new Error("Context is not initialized!");
+  }
+}
 
 export interface RequestState {
   user: User | null;
+  context: Context;
 }
 
 export interface Session {

--- a/utils/session.test.ts
+++ b/utils/session.test.ts
@@ -1,18 +1,19 @@
 import { expect } from "@std/expect";
-import { decodeSession, encodeSession } from "./session.ts";
+import { createSessionKeyAndIv, decodeSession, encodeSession } from "./session.ts";
 
 Deno.test("encoding and decoding of sessions", async (t) => {
   const mySession = { userId: 165 };
   let encoded = "";
+  const sessionKeyAndIv = await createSessionKeyAndIv("bGV0IHVzIGdvCg==")
 
   await t.step("encoding", async () => {
-    encoded = await encodeSession(mySession);
+    encoded = await encodeSession(mySession, sessionKeyAndIv);
 
     expect(encoded).not.toBe(JSON.stringify(mySession));
   });
 
   await t.step("decoding", async () => {
-    const decoded = await decodeSession(encoded);
+    const decoded = await decodeSession(encoded, sessionKeyAndIv);
 
     expect(decoded).toEqual(mySession);
   });

--- a/utils/session.test.ts
+++ b/utils/session.test.ts
@@ -1,10 +1,14 @@
 import { expect } from "@std/expect";
-import { createSessionKeyAndIv, decodeSession, encodeSession } from "./session.ts";
+import {
+  createSessionKeyAndIv,
+  decodeSession,
+  encodeSession,
+} from "./session.ts";
 
 Deno.test("encoding and decoding of sessions", async (t) => {
   const mySession = { userId: 165 };
   let encoded = "";
-  const sessionKeyAndIv = await createSessionKeyAndIv("bGV0IHVzIGdvCg==")
+  const sessionKeyAndIv = await createSessionKeyAndIv("bGV0IHVzIGdvCg==");
 
   await t.step("encoding", async () => {
     encoded = await encodeSession(mySession, sessionKeyAndIv);

--- a/utils/session.ts
+++ b/utils/session.ts
@@ -15,11 +15,13 @@ const te = (s: string) => new TextEncoder().encode(s);
 const td = (d: Uint8Array) => new TextDecoder().decode(d);
 
 export type SessionKeyAndIv = {
-  key: CryptoKey,
-  iv: Uint8Array,
-}
+  key: CryptoKey;
+  iv: Uint8Array;
+};
 
-export async function createSessionKeyAndIv(sessionToken: string): Promise<SessionKeyAndIv> {
+export async function createSessionKeyAndIv(
+  sessionToken: string,
+): Promise<SessionKeyAndIv> {
   const rawKey = te(sessionToken);
   const key = await crypto.subtle.importKey(
     "raw",
@@ -29,10 +31,13 @@ export async function createSessionKeyAndIv(sessionToken: string): Promise<Sessi
     ["encrypt", "decrypt"],
   );
 
-  return { key, iv: new Uint8Array(16) }
+  return { key, iv: new Uint8Array(16) };
 }
 
-export async function encodeSession(session: Session, { key, iv }: SessionKeyAndIv): Promise<string> {
+export async function encodeSession(
+  session: Session,
+  { key, iv }: SessionKeyAndIv,
+): Promise<string> {
   if (!session.userId) {
     throw Error(`invalid session of: ${JSON.stringify(session)}`);
   }
@@ -48,7 +53,10 @@ export async function encodeSession(session: Session, { key, iv }: SessionKeyAnd
   return encodeBase64(encryptedBytes);
 }
 
-export async function decodeSession(encoded: string, { key, iv }: SessionKeyAndIv): Promise<Session> {
+export async function decodeSession(
+  encoded: string,
+  { key, iv }: SessionKeyAndIv,
+): Promise<Session> {
   const decrypted = await crypto.subtle.decrypt(
     { name: "AES-CBC", iv },
     key,


### PR DESCRIPTION
A biggish refactor to adding Context to server requests. 

TL;DR
Most of this stuff is probably not really important, but how to access the DB is easier:
[You can see an example here](https://github.com/tokyomovie/tokyomovie/pull/23/files#diff-6e3404c5da8f047b80ad23cc30a21a8b67b577f946f0b93f9c2d3b9c784c01b7R17)

- Adds Context so that requests can have access to various utilities easily
  - Adds session info to this context for session creation (this is rarely used, so not really important)
  - Adds db, so db can be used on every request without import
    - You can now get a reference to the `db` in your routes on the request `ctx`, please see [here](https://github.com/tokyomovie/tokyomovie/pull/23/files#diff-6e3404c5da8f047b80ad23cc30a21a8b67b577f946f0b93f9c2d3b9c784c01b7R17) for an example
  - As an extra note, this allows us to do more stuff on server initialization...not sure what that would be, but yeah, it's just cleaner 
- Adds Dockerfile - just because I'll probably use this for deployment

## More info

https://fresh.deno.dev/docs/concepts/deployment#-docker
https://fresh.deno.dev/docs/examples/init-the-server